### PR TITLE
scripts: twister: Unrecognized section test solution 4

### DIFF
--- a/scripts/pylib/twister/twisterlib/config_parser.py
+++ b/scripts/pylib/twister/twisterlib/config_parser.py
@@ -49,6 +49,7 @@ class TwisterConfigParser:
                        "extra_conf_files": {"type": "list", "default": []},
                        "extra_overlay_confs" : {"type": "list", "default": []},
                        "extra_dtc_overlay_files": {"type": "list", "default": []},
+                       "fail_on_unrecognized_section_test": {"type": "bool", "default": False},
                        "required_snippets": {"type": "list"},
                        "build_only": {"type": "bool", "default": False},
                        "build_on_all": {"type": "bool", "default": False},

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -82,6 +82,8 @@ Artificially long but functional example:
 
     test_xor_generator = case_select.add_mutually_exclusive_group()
 
+    unrecognized_section_test_group = parser.add_mutually_exclusive_group()
+
     valgrind_asan_group = parser.add_mutually_exclusive_group()
 
     case_select.add_argument(
@@ -345,10 +347,16 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
                         dest="enable_asserts",
                         help="deprecated, left for compatibility")
 
-    parser.add_argument(
+    unrecognized_section_test_group.add_argument(
         "--disable-unrecognized-section-test", action="store_true",
         default=False,
         help="Skip the 'unrecognized section' test.")
+
+    unrecognized_section_test_group.add_argument(
+        "--fail-on-unrecognized-section-test", action="store_true",
+        default=False,
+        help="The 'unrecognized section' test will now fail the testcase, "
+             "rather than just sending out a warning.")
 
     parser.add_argument(
         "--disable-suite-name-check", action="store_true", default=False,

--- a/scripts/pylib/twister/twisterlib/reports.py
+++ b/scripts/pylib/twister/twisterlib/reports.py
@@ -456,16 +456,11 @@ class Reporting:
                         f"{example_instance.testsuite.source_dir_rel} -T {example_instance.testsuite.id}")
             logger.info("-+" * 40)
 
-    def summary(self, results, unrecognized_sections, duration):
+    def summary(self, results, duration):
         failed = 0
         run = 0
         for instance in self.instances.values():
             if instance.status == "failed":
-                failed += 1
-            elif instance.metrics.get("unrecognized") and not unrecognized_sections:
-                logger.error("%sFAILED%s: %s has unrecognized binary sections: %s" %
-                             (Fore.RED, Fore.RESET, instance.name,
-                              str(instance.metrics.get("unrecognized", []))))
                 failed += 1
 
             # FIXME: need a better way to identify executed tests

--- a/scripts/pylib/twister/twisterlib/twister_main.py
+++ b/scripts/pylib/twister/twisterlib/twister_main.py
@@ -197,7 +197,7 @@ def main(options):
     if VERBOSE > 1:
         runner.results.summary()
 
-    report.summary(runner.results, options.disable_unrecognized_section_test, duration)
+    report.summary(runner.results, duration)
 
     coverage_completed = True
     if options.coverage:

--- a/scripts/schemas/twister/testsuite-schema.yaml
+++ b/scripts/schemas/twister/testsuite-schema.yaml
@@ -65,6 +65,9 @@ schema;scenario-schema:
       required: false
       sequence:
         - type: str
+    "fail_on_unrecognized_section_test":
+      type: bool
+      required: false
     "filter":
       type: str
       required: false

--- a/scripts/tests/twister_blackbox/test_disable.py
+++ b/scripts/tests/twister_blackbox/test_disable.py
@@ -14,6 +14,7 @@ import sys
 import re
 
 from conftest import ZEPHYR_BASE, TEST_DATA, testsuite_filename_mock
+from twisterlib.size_calc import SizeCalculator
 from twisterlib.testplan import TestPlan
 
 
@@ -126,3 +127,30 @@ class TestDisable:
 
         assert str(sys_exit.value) == expected_exit_code, \
             f"Twister return not expected ({expected_exit_code}) exit code: ({sys_exit.value})"
+
+    @pytest.mark.parametrize(
+        'flags, expected_result',
+        [
+            ([], '1'),
+            (['--disable-unrecognized-section-test'], '0')
+        ],
+        ids=['no disable flag', 'disabled']
+    )
+    @mock.patch.object(TestPlan, 'TESTSUITE_FILENAME', testsuite_filename_mock)
+    # This mock makes all read only sections unrecognized, so the dus test fails the run.
+    @mock.patch.object(SizeCalculator, 'ro_sections', [])
+    def test_disable_unrecognized_section_test(self, out_path, flags, expected_result):
+        test_platforms = ['frdm_k64f']
+        path = os.path.join(TEST_DATA, 'tests', 'dummy', 'device', 'group')
+        args = ['-i', '--outdir', out_path, '-T', path] + \
+               flags + \
+               ['--enable-size-report'] + \
+               [val for pair in zip(
+                   ['-p'] * len(test_platforms), test_platforms
+               ) for val in pair]
+
+        with mock.patch.object(sys, 'argv', [sys.argv[0]] + args), \
+                pytest.raises(SystemExit) as exc:
+            self.loader.exec_module(self.twister_module)
+
+        assert str(exc.value) == expected_result


### PR DESCRIPTION
This solution to the unrecognized section test crisis makes the check raise warnings instead of errors by default.

Users as well as test creators are able to elevate warns to error via CLI flags and testcase.yaml.